### PR TITLE
DST + Hourglass ICD

### DIFF
--- a/src/commonMain/kotlin/data/buffs/DragonspineTrophy.kt
+++ b/src/commonMain/kotlin/data/buffs/DragonspineTrophy.kt
@@ -25,6 +25,10 @@ class DragonspineTrophy : Buff() {
 
         override val type: Type = Type.PPM
         override val ppm: Double = 1.0
+        override fun cooldownMs(sp: SimParticipant): Int = 20000
+        //TODO: check if this has an ICD, conflicting information in wowhead comments (might of been nerfed in 2.2)
+        //20 sec ICD data in wow.tools 2.5.1 build
+
 
         val buff = object : Buff() {
             override val name: String = "Dragonspine Trophy"

--- a/src/commonMain/kotlin/data/buffs/RageOfTheUnraveller.kt
+++ b/src/commonMain/kotlin/data/buffs/RageOfTheUnraveller.kt
@@ -23,6 +23,10 @@ class RageOfTheUnraveller : Buff() {
 
         override val type: Type = Type.PPM
         override val ppm: Double = 1.0
+        override fun cooldownMs(sp: SimParticipant): Int = 50000
+        //TODO: check if this has an ICD, conflicting information in wowhead comments (might of been nerfed in 2.2)
+        //50 sec ICD data in wow.tools 2.5.1 build
+
 
         val buff = object : Buff() {
             override val name: String = "Rage of the Unraveller"


### PR DESCRIPTION
Added ICD to Dragonspine Trophy and Hourglass of the Unraveller based off datamined patch 2.5.1 (checked all other current proc trinket implemented and seem to match datamined info)