### PR TITLE
RAP and Thundering Skyfire Diamond

### DIFF
--- a/src/commonMain/kotlin/data/abilities/generic/FlaskOfRelentlessAssault.kt
+++ b/src/commonMain/kotlin/data/abilities/generic/FlaskOfRelentlessAssault.kt
@@ -18,7 +18,10 @@ class FlaskOfRelentlessAssault : Ability() {
         override val mutex: List<Mutex> = listOf(Mutex.BATTLE_ELIXIR, Mutex.GUARDIAN_ELIXIR)
 
         override fun modifyStats(sp: SimParticipant): Stats {
-            return Stats(attackPower = 120)
+            return Stats(
+                attackPower = 120,
+                rangedAttackPower = 120
+            )
         }
     }
 

--- a/src/commonMain/kotlin/data/buffs/BloodlustBrooch.kt
+++ b/src/commonMain/kotlin/data/buffs/BloodlustBrooch.kt
@@ -20,7 +20,10 @@ class BloodlustBrooch : Buff() {
         override val durationMs: Int = buffDurationMs
 
         override fun modifyStats(sp: SimParticipant): Stats? {
-            return Stats(attackPower = 278)
+            return Stats(
+                attackPower = 278,
+                rangedAttackPower = 278
+            )
         }
     }
 

--- a/src/commonMain/kotlin/data/buffs/DarkmoonCardCrusadeAP.kt
+++ b/src/commonMain/kotlin/data/buffs/DarkmoonCardCrusadeAP.kt
@@ -24,7 +24,10 @@ class DarkmoonCardCrusadeAP : Buff() {
 
         override fun modifyStats(sp: SimParticipant): Stats {
             val stacks = state(sp).currentStacks
-            return Stats(attackPower = 6 * stacks)
+            return Stats(
+                attackPower = 6 * stacks,
+                rangedAttackPower = 6 * stacks
+            )
         }
     }
 

--- a/src/commonMain/kotlin/data/buffs/FigurineNightseyePanther.kt
+++ b/src/commonMain/kotlin/data/buffs/FigurineNightseyePanther.kt
@@ -20,7 +20,10 @@ class FigurineNightseyePanther : Buff() {
         override val durationMs: Int = buffDurationMs
 
         override fun modifyStats(sp: SimParticipant): Stats? {
-            return Stats(attackPower = 320)
+            return Stats(
+                attackPower = 320,
+                rangedAttackPower = 320
+            )
         }
     }
 

--- a/src/commonMain/kotlin/data/buffs/RageOfTheUnraveller.kt
+++ b/src/commonMain/kotlin/data/buffs/RageOfTheUnraveller.kt
@@ -33,7 +33,10 @@ class RageOfTheUnraveller : Buff() {
             override val durationMs: Int = 10000
 
             override fun modifyStats(sp: SimParticipant): Stats {
-                return Stats(attackPower = 300)
+                return Stats(
+                    attackPower = 300,
+                    rangedAttackPower = 300
+                )
             }
         }
 

--- a/src/commonMain/kotlin/data/buffs/TsunamiTalisman.kt
+++ b/src/commonMain/kotlin/data/buffs/TsunamiTalisman.kt
@@ -29,7 +29,10 @@ class TsunamiTalisman : Buff() {
             override val durationMs: Int = 10000
 
             override fun modifyStats(sp: SimParticipant): Stats? {
-                return Stats(attackPower = 340)
+                return Stats(
+                    attackPower = 340,
+                    rangedAttackPower = 340
+                )
             }
         }
         override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {

--- a/src/commonMain/kotlin/data/gems/ThunderingSkyfireDiamond.kt
+++ b/src/commonMain/kotlin/data/gems/ThunderingSkyfireDiamond.kt
@@ -17,8 +17,8 @@ class ThunderingSkyfireDiamond : Gem(32410,"Thundering Skyfire Diamond", "inv_mi
 
     val hasteBuff = object : Buff() {
         override val name: String = "Thundering Skyfire Diamond"
-        override val durationMs: Int = 10000
-
+        override val durationMs: Int = 6000
+        //https://tbc.wowhead.com/spell=39959/skyfire-swiftness 6 seconds in 2.5.1 data
         override fun modifyStats(sp: SimParticipant): Stats {
             return Stats(physicalHasteRating = 240.0)
         }

--- a/src/commonMain/kotlin/data/itemsets/DesolationBattlegear.kt
+++ b/src/commonMain/kotlin/data/itemsets/DesolationBattlegear.kt
@@ -36,7 +36,10 @@ class DesolationBattlegear : ItemSet() {
             override val durationMs: Int = 15000
 
             override fun modifyStats(sp: SimParticipant): Stats {
-                return Stats(attackPower = 160)
+                return Stats(
+                    attackPower = 160,
+                    rangedAttackPower = 160
+                )
             }
         }
 

--- a/src/commonMain/kotlin/data/itemsets/WastewalkerArmor.kt
+++ b/src/commonMain/kotlin/data/itemsets/WastewalkerArmor.kt
@@ -35,7 +35,10 @@ class WastewalkerArmor : ItemSet() {
             override val durationMs: Int = 15000
 
             override fun modifyStats(sp: SimParticipant): Stats {
-                return Stats(attackPower = 160)
+                return Stats(
+                    attackPower = 160,
+                    rangedAttackPower = 160
+                )
             }
         }
 


### PR DESCRIPTION
- Updated items to include RAP that should of had RAP
- Updated Duration of Thundering Skyfire Diamond to 6 seconds (from 10) based on 2.5.1 data