### PR TITLE
P1 Item Procs

### DIFF
--- a/src/commonMain/kotlin/data/buffs/BlackoutTruncheon.kt
+++ b/src/commonMain/kotlin/data/buffs/BlackoutTruncheon.kt
@@ -1,0 +1,46 @@
+package data.buffs
+
+import character.*
+import data.model.Item
+import sim.Event
+import sim.SimParticipant
+
+class BlackoutTruncheon(val sourceItem: Item) : ItemBuff(listOf(sourceItem)) {
+    override val id: Int = 33489
+    override val name: String = "Blackout Truncheon (static)"
+    override val durationMs: Int = -1
+    override val hidden: Boolean = true
+
+    val proc = object : ItemProc(listOf(sourceItem)) {
+        override val triggers: List<Trigger> = listOf(
+            Trigger.MELEE_AUTO_HIT,
+            Trigger.MELEE_AUTO_CRIT,
+            Trigger.MELEE_WHITE_HIT,
+            Trigger.MELEE_WHITE_CRIT,
+            Trigger.MELEE_YELLOW_HIT,
+            Trigger.MELEE_YELLOW_CRIT,
+            Trigger.MELEE_BLOCK,
+            Trigger.MELEE_GLANCE,
+        )
+
+        override val type: Type = Type.PPM
+        override val ppm: Double = 2.0
+        //TODO: confirm its 2.0PPM based on wowhead comments
+
+
+        val buff = object : Buff() {
+            override val name: String = "Blackout Truncheon"
+            override val durationMs: Int = 10000
+
+            override fun modifyStats(sp: SimParticipant): Stats {
+                return Stats(physicalHasteRating = 132.00)
+            }
+        }
+
+        override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {
+            sp.addBuff(buff)
+        }
+    }
+
+    override fun procs(sp: SimParticipant): List<Proc> = listOf(proc)
+}

--- a/src/commonMain/kotlin/data/buffs/Buffs.kt
+++ b/src/commonMain/kotlin/data/buffs/Buffs.kt
@@ -116,6 +116,16 @@ object Buffs {
             39438 -> DarkmoonCardCrusadeAP()
             39440 -> DarkmoonCardCrusadeSP()
             42083 -> TsunamiTalisman()
+            34513 -> Lionheart(item)
+            34696 -> GlaiveOfThePit(item)
+            34580 -> Despair(item)
+            35131 -> TheBladefist(item)
+            33489 -> BlackoutTruncheon(item)
+            34107 -> Revenger(item)
+            16916 -> KhoriumChampion(item)
+            38282 -> SingingCrystalAxe(item)
+            38284 -> TheHammerOfDestiny(item)
+            38307 -> TheNightBlade(item)
 
             // All the random mp5 buffs
             18378 -> GenericManaRegenBuff(8)

--- a/src/commonMain/kotlin/data/buffs/Despair.kt
+++ b/src/commonMain/kotlin/data/buffs/Despair.kt
@@ -1,0 +1,56 @@
+package data.buffs
+
+import character.*
+import data.Constants
+import data.model.Item
+import mechanics.Melee
+import sim.Event
+import sim.SimParticipant
+
+class Despair(val sourceItem: Item) : ItemBuff(listOf(sourceItem)) {
+    override val name: String = "Despair (static)"
+    override val durationMs: Int = -1
+    override val hidden: Boolean = true
+
+        val procAbility = object : Ability() {
+            override val id: Int = 34580
+            override val name: String = "Despair"
+            override fun gcdMs(sp: SimParticipant): Int = 0
+            override fun cast(sp: SimParticipant) {
+                val item = sp.character.gear.mainHand
+                val result = Melee.attackRoll(sp, 600.0, item , isWhiteDmg = false)
+
+                val damageEvent = Event(
+                    eventType = Event.Type.DAMAGE,
+                    damageType = Constants.DamageType.PHYSICAL_IGNORE_ARMOR,
+                    abilityName = name,
+                    amount = result.first,
+                    result = result.second,
+                )
+                sp.logEvent(damageEvent)
+            }
+        }
+
+        val proc = object : ItemProc(listOf(sourceItem)) {
+            override val triggers: List<Trigger> = listOf(
+                Trigger.MELEE_AUTO_HIT,
+                Trigger.MELEE_AUTO_CRIT,
+                Trigger.MELEE_WHITE_HIT,
+                Trigger.MELEE_WHITE_CRIT,
+                Trigger.MELEE_YELLOW_HIT,
+                Trigger.MELEE_YELLOW_CRIT,
+                Trigger.MELEE_GLANCE,
+                Trigger.MELEE_BLOCK
+            )
+            override val type: Type = Type.PPM
+            override val ppm: Double = 0.5
+            //based on wowhead comments (approximation) TODO: check live procrate
+
+            override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {
+                procAbility.cast(sp)
+            }
+        }
+
+        override fun procs(sp: SimParticipant): List<Proc> = listOf(proc)
+}
+

--- a/src/commonMain/kotlin/data/buffs/GlaiveOfThePit.kt
+++ b/src/commonMain/kotlin/data/buffs/GlaiveOfThePit.kt
@@ -1,0 +1,59 @@
+package data.buffs
+
+import character.*
+import data.Constants
+import data.model.Item
+import mechanics.Spell
+import sim.Event
+import sim.SimParticipant
+
+class GlaiveOfThePit(val sourceItem: Item) : ItemBuff(listOf(sourceItem)) {
+    override val name: String = "Glaive of the Pit (static)"
+    override val durationMs: Int = -1
+    override val hidden: Boolean = true
+
+        val shadowAbility = object : Ability() {
+            override val id: Int = 34696
+            override val name: String = "Glaive of the Pit (Shadow)"
+            override fun gcdMs(sp: SimParticipant): Int = 0
+
+            val school = Constants.DamageType.SHADOW
+            override fun cast(sp: SimParticipant) {
+                val damageRoll = Spell.baseDamageRoll(sp, 285.00, 315.0, 0.0, school)
+                //Doesn't appear to have a spell damage coeff (some life steal effects do)
+                //TODO: check if the damage proc scales with increased shadow damage debuffs e.g. shadow weaving
+                val result = Spell.attackRoll(sp, damageRoll, school)
+
+                val damageEvent = Event(
+                    eventType = Event.Type.DAMAGE,
+                    damageType = school,
+                    abilityName = name,
+                    amount = result.first,
+                    result = result.second,
+                )
+                sp.logEvent(damageEvent)
+            }
+        }
+
+        val shadowProc = object : ItemProc(listOf(sourceItem)) {
+            override val triggers: List<Trigger> = listOf(
+                Trigger.MELEE_AUTO_HIT,
+                Trigger.MELEE_AUTO_CRIT,
+                Trigger.MELEE_WHITE_HIT,
+                Trigger.MELEE_WHITE_CRIT,
+                Trigger.MELEE_YELLOW_HIT,
+                Trigger.MELEE_YELLOW_CRIT,
+                Trigger.MELEE_GLANCE,
+                Trigger.MELEE_BLOCK
+            )
+            override val type: Type = Type.PPM
+            override val ppm: Double = 1.5
+            //proc chance based on wowhead comments
+            override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {
+                shadowAbility.cast(sp)
+            }
+        }
+
+        override fun procs(sp: SimParticipant): List<Proc> = listOf(shadowProc)
+}
+

--- a/src/commonMain/kotlin/data/buffs/KhoriumChampion.kt
+++ b/src/commonMain/kotlin/data/buffs/KhoriumChampion.kt
@@ -1,0 +1,46 @@
+package data.buffs
+
+import character.*
+import data.model.Item
+import sim.Event
+import sim.SimParticipant
+
+class KhoriumChampion(val sourceItem: Item) : ItemBuff(listOf(sourceItem)) {
+    override val id: Int = 16916
+    override val name: String = "Khorium Champion (static)"
+    override val durationMs: Int = -1
+    override val hidden: Boolean = true
+
+    val proc = object : ItemProc(listOf(sourceItem)) {
+        override val triggers: List<Trigger> = listOf(
+            Trigger.MELEE_AUTO_HIT,
+            Trigger.MELEE_AUTO_CRIT,
+            Trigger.MELEE_WHITE_HIT,
+            Trigger.MELEE_WHITE_CRIT,
+            Trigger.MELEE_YELLOW_HIT,
+            Trigger.MELEE_YELLOW_CRIT,
+            Trigger.MELEE_BLOCK,
+            Trigger.MELEE_GLANCE,
+        )
+
+        override val type: Type = Type.PPM
+        override val ppm: Double = 1.0
+        //TODO:Confirm proc rate, based on wowhead comments
+
+
+        val buff = object : Buff() {
+            override val name: String = "Khorium Champion"
+            override val durationMs: Int = 30000
+
+            override fun modifyStats(sp: SimParticipant): Stats {
+                return Stats(strength = 120)
+            }
+        }
+
+        override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {
+            sp.addBuff(buff)
+        }
+    }
+
+    override fun procs(sp: SimParticipant): List<Proc> = listOf(proc)
+}

--- a/src/commonMain/kotlin/data/buffs/Lionheart.kt
+++ b/src/commonMain/kotlin/data/buffs/Lionheart.kt
@@ -1,0 +1,47 @@
+package data.buffs
+
+import character.*
+import data.model.Item
+import sim.Event
+import sim.SimParticipant
+
+class Lionheart(val sourceItem: Item) : ItemBuff(listOf(sourceItem)) {
+    override val id: Int = 34513
+    override val name: String = "Lionheart (static)"
+    override val durationMs: Int = -1
+    override val hidden: Boolean = true
+
+    val proc = object : ItemProc(listOf(sourceItem)) {
+        override val triggers: List<Trigger> = listOf(
+            Trigger.MELEE_AUTO_HIT,
+            Trigger.MELEE_AUTO_CRIT,
+            Trigger.MELEE_WHITE_HIT,
+            Trigger.MELEE_WHITE_CRIT,
+            Trigger.MELEE_YELLOW_HIT,
+            Trigger.MELEE_YELLOW_CRIT,
+            Trigger.MELEE_BLOCK,
+            Trigger.MELEE_GLANCE,
+        )
+
+        override val type: Type = Type.PPM
+        override val ppm: Double = 3.0
+        override fun cooldownMs(sp: SimParticipant): Int = 1000
+        //TODO: confirm its 3.0 PPM and 1 second ICD (only present in wowhead data can't see it on wow.tools)
+
+
+        val buff = object : Buff() {
+            override val name: String = "Lionheart"
+            override val durationMs: Int = 10000
+
+            override fun modifyStats(sp: SimParticipant): Stats {
+                return Stats(strength = 100)
+            }
+        }
+
+        override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {
+            sp.addBuff(buff)
+        }
+    }
+
+    override fun procs(sp: SimParticipant): List<Proc> = listOf(proc)
+}

--- a/src/commonMain/kotlin/data/buffs/Revenger.kt
+++ b/src/commonMain/kotlin/data/buffs/Revenger.kt
@@ -1,0 +1,59 @@
+package data.buffs
+
+import character.*
+import data.Constants
+import data.model.Item
+import mechanics.Spell
+import sim.Event
+import sim.SimParticipant
+
+class Revenger(val sourceItem: Item) : ItemBuff(listOf(sourceItem)) {
+    override val name: String = "Revenger (static)"
+    override val durationMs: Int = -1
+    override val hidden: Boolean = true
+
+        val shadowAbility = object : Ability() {
+            override val id: Int = 34107
+            override val name: String = "Revenger (Shadow)"
+            override fun gcdMs(sp: SimParticipant): Int = 0
+
+            val school = Constants.DamageType.SHADOW
+            override fun cast(sp: SimParticipant) {
+                val damageRoll = Spell.baseDamageRoll(sp, 105.00, 125.0, 1.0, school)
+                //Has 100% Spell Damage scaling (from the wow Armaments Discord)
+                //TODO: check if the damage proc scales with increased shadow damage debuffs e.g. shadow weaving
+                val result = Spell.attackRoll(sp, damageRoll, school)
+
+                val damageEvent = Event(
+                    eventType = Event.Type.DAMAGE,
+                    damageType = school,
+                    abilityName = name,
+                    amount = result.first,
+                    result = result.second,
+                )
+                sp.logEvent(damageEvent)
+            }
+        }
+
+        val shadowProc = object : ItemProc(listOf(sourceItem)) {
+            override val triggers: List<Trigger> = listOf(
+                Trigger.MELEE_AUTO_HIT,
+                Trigger.MELEE_AUTO_CRIT,
+                Trigger.MELEE_WHITE_HIT,
+                Trigger.MELEE_WHITE_CRIT,
+                Trigger.MELEE_YELLOW_HIT,
+                Trigger.MELEE_YELLOW_CRIT,
+                Trigger.MELEE_GLANCE,
+                Trigger.MELEE_BLOCK
+            )
+            override val type: Type = Type.PPM
+            override val ppm: Double = 1.0
+            //proc chance based on wowhead comments (approximation)
+            override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {
+                shadowAbility.cast(sp)
+            }
+        }
+
+        override fun procs(sp: SimParticipant): List<Proc> = listOf(shadowProc)
+}
+

--- a/src/commonMain/kotlin/data/buffs/SingingCrystalAxe.kt
+++ b/src/commonMain/kotlin/data/buffs/SingingCrystalAxe.kt
@@ -1,0 +1,46 @@
+package data.buffs
+
+import character.*
+import data.model.Item
+import sim.Event
+import sim.SimParticipant
+
+class SingingCrystalAxe(val sourceItem: Item) : ItemBuff(listOf(sourceItem)) {
+    override val id: Int = 38282
+    override val name: String = "Singing Crystal Axe (static)"
+    override val durationMs: Int = -1
+    override val hidden: Boolean = true
+
+    val proc = object : ItemProc(listOf(sourceItem)) {
+        override val triggers: List<Trigger> = listOf(
+            Trigger.MELEE_AUTO_HIT,
+            Trigger.MELEE_AUTO_CRIT,
+            Trigger.MELEE_WHITE_HIT,
+            Trigger.MELEE_WHITE_CRIT,
+            Trigger.MELEE_YELLOW_HIT,
+            Trigger.MELEE_YELLOW_CRIT,
+            Trigger.MELEE_BLOCK,
+            Trigger.MELEE_GLANCE,
+        )
+
+        override val type: Type = Type.PPM
+        override val ppm: Double = 1.0
+        //TODO:Confirm proc rate, based on wowwiki
+
+
+        val buff = object : Buff() {
+            override val name: String = "Singing Crystal Axe"
+            override val durationMs: Int = 10000
+
+            override fun modifyStats(sp: SimParticipant): Stats {
+                return Stats(physicalHasteRating = 400.00)
+            }
+        }
+
+        override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {
+            sp.addBuff(buff)
+        }
+    }
+
+    override fun procs(sp: SimParticipant): List<Proc> = listOf(proc)
+}

--- a/src/commonMain/kotlin/data/buffs/TheBladefist.kt
+++ b/src/commonMain/kotlin/data/buffs/TheBladefist.kt
@@ -1,0 +1,48 @@
+package data.buffs
+
+import character.*
+import data.model.Item
+import sim.Event
+import sim.SimParticipant
+
+class TheBladefist(val sourceItem: Item) : ItemBuff(listOf(sourceItem)) {
+    override val id: Int = 35131
+    override val name: String = "The Bladefist (static)"
+    override val durationMs: Int = -1
+    override val hidden: Boolean = true
+
+    val proc = object : ItemProc(listOf(sourceItem)) {
+        override val triggers: List<Trigger> = listOf(
+            Trigger.MELEE_AUTO_HIT,
+            Trigger.MELEE_AUTO_CRIT,
+            Trigger.MELEE_WHITE_HIT,
+            Trigger.MELEE_WHITE_CRIT,
+            Trigger.MELEE_YELLOW_HIT,
+            Trigger.MELEE_YELLOW_CRIT,
+            Trigger.MELEE_BLOCK,
+            Trigger.MELEE_GLANCE,
+        )
+
+        override val type: Type = Type.PPM
+        override val ppm: Double = 3.0
+        override fun cooldownMs(sp: SimParticipant): Int = 45000
+        //ICD from wow.tools
+        //3PPM from wowhead comments TODO: check live procrate
+
+
+        val buff = object : Buff() {
+            override val name: String = "The Bladefist"
+            override val durationMs: Int = 10000
+
+            override fun modifyStats(sp: SimParticipant): Stats {
+                return Stats(physicalHasteRating = 180.0)
+            }
+        }
+
+        override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {
+            sp.addBuff(buff)
+        }
+    }
+
+    override fun procs(sp: SimParticipant): List<Proc> = listOf(proc)
+}

--- a/src/commonMain/kotlin/data/buffs/TheHammerOfDestiny.kt
+++ b/src/commonMain/kotlin/data/buffs/TheHammerOfDestiny.kt
@@ -1,0 +1,47 @@
+package data.buffs
+
+import character.*
+import data.model.Item
+import sim.Event
+import sim.SimParticipant
+import kotlin.random.Random
+
+class TheHammerOfDestiny(val sourceItem: Item) : ItemBuff(listOf(sourceItem)) {
+    override val id: Int = 38284
+    override val name: String = "The Hammer of Destiny (static)"
+    override val durationMs: Int = -1
+    override val hidden: Boolean = true
+
+    val proc = object : ItemProc(listOf(sourceItem)) {
+        override val triggers: List<Trigger> = listOf(
+            Trigger.MELEE_AUTO_HIT,
+            Trigger.MELEE_AUTO_CRIT,
+            Trigger.MELEE_WHITE_HIT,
+            Trigger.MELEE_WHITE_CRIT,
+            Trigger.MELEE_YELLOW_HIT,
+            Trigger.MELEE_YELLOW_CRIT,
+            Trigger.MELEE_BLOCK,
+            Trigger.MELEE_GLANCE,
+        )
+
+        override val type: Type = Type.PPM
+        override val ppm: Double = 3.0
+        //TODO:Confirm proc rate, based on wowhead comment, test when ret is added
+    val manaRestore = object : Ability(){
+            override val id: Int = 34107
+            override val name: String = "The Hammer of Destiny"
+            override fun gcdMs(sp: SimParticipant): Int = 0
+
+            override fun cast(sp: SimParticipant) {
+                val manaRestored = Random.nextInt(170, 230)
+                sp.addResource(manaRestored, Resource.Type.MANA, name)
+            }
+
+    }
+        override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {
+            manaRestore.cast(sp)
+        }
+    }
+
+    override fun procs(sp: SimParticipant): List<Proc> = listOf(proc)
+}

--- a/src/commonMain/kotlin/data/buffs/TheNightBlade.kt
+++ b/src/commonMain/kotlin/data/buffs/TheNightBlade.kt
@@ -1,0 +1,48 @@
+package data.buffs
+
+import character.*
+import data.model.Item
+import sim.Event
+import sim.SimParticipant
+
+class TheNightBlade(val sourceItem: Item) : ItemBuff(listOf(sourceItem)) {
+    override val id: Int = 38307
+    override val name: String = "The Night Blade (static)"
+    override val durationMs: Int = -1
+    override val hidden: Boolean = true
+
+    val buff = object : Buff(){
+        override val name: String = "The Night Blade"
+        override val durationMs: Int =  10000
+        override val maxStacks: Int = 3
+
+        override fun modifyStats(sp: SimParticipant): Stats {
+            val stacks = state(sp).currentStacks
+            return Stats(
+                armorPen = 435 * stacks
+            )
+        }
+
+    }
+
+    val stackProc = object : ItemProc(listOf(sourceItem)) {
+        override val triggers: List<Trigger> = listOf(
+            Trigger.MELEE_AUTO_HIT,
+            Trigger.MELEE_AUTO_CRIT,
+            Trigger.MELEE_WHITE_HIT,
+            Trigger.MELEE_WHITE_CRIT,
+            Trigger.MELEE_YELLOW_HIT,
+            Trigger.MELEE_YELLOW_CRIT,
+            Trigger.MELEE_BLOCK,
+            Trigger.MELEE_GLANCE,
+        )
+        override val type: Type = Type.PPM
+        override val ppm: Double = 2.0
+
+        override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {
+            sp.addBuff(buff)
+        }
+    }
+
+    override fun procs(sp: SimParticipant): List<Proc> = listOf(stackProc)
+}

--- a/src/commonMain/kotlin/mechanics/Melee.kt
+++ b/src/commonMain/kotlin/mechanics/Melee.kt
@@ -47,7 +47,6 @@ object Melee {
         Constants.ItemSubclass.MACE_1H to 2400.0,
         Constants.ItemSubclass.SWORD_1H to 2400.0,
         Constants.ItemSubclass.FIST to 2400.0,
-        Constants.ItemSubclass.POLEARM to 3300.00,
         // TODO: Druid weirdness
     )
 

--- a/src/commonMain/kotlin/mechanics/Melee.kt
+++ b/src/commonMain/kotlin/mechanics/Melee.kt
@@ -46,6 +46,7 @@ object Melee {
         Constants.ItemSubclass.MACE_1H to 2400.0,
         Constants.ItemSubclass.SWORD_1H to 2400.0,
         Constants.ItemSubclass.FIST to 2400.0,
+        Constants.ItemSubclass.POLEARM to 3300.00,
         // TODO: Druid weirdness
     )
 

--- a/src/commonMain/kotlin/mechanics/Melee.kt
+++ b/src/commonMain/kotlin/mechanics/Melee.kt
@@ -41,6 +41,7 @@ object Melee {
         Constants.ItemSubclass.AXE_2H to 3300.0,
         Constants.ItemSubclass.MACE_2H to 3300.0,
         Constants.ItemSubclass.SWORD_2H to 3300.0,
+        Constants.ItemSubclass.POLEARM to 3300.0,
         Constants.ItemSubclass.DAGGER to 1700.0,
         Constants.ItemSubclass.AXE_1H to 2400.0,
         Constants.ItemSubclass.MACE_1H to 2400.0,


### PR DESCRIPTION
Most of the proc rates are based on questionable wowhead comments or wowwiki, will need to update the proc rates when testing has been done. Blinkstrike still needs to be added to complete all p1 weapon procs