### PR TITLE
Multiple resource types for a participant, for Rogues/Druids

### DIFF
--- a/src/commonMain/kotlin/character/Class.kt
+++ b/src/commonMain/kotlin/character/Class.kt
@@ -74,7 +74,7 @@ abstract class Class(
     abstract fun talentFromString(name: String, ranks: Int): Talent?
 
     // Class resource
-    abstract val resourceType: Resource.Type
+    abstract val resourceType: List<Resource.Type>
 
     abstract val canDualWield: Boolean
 

--- a/src/commonMain/kotlin/character/Resource.kt
+++ b/src/commonMain/kotlin/character/Resource.kt
@@ -3,7 +3,8 @@ package character
 import sim.SimParticipant
 
 class Resource(
-    val sp: SimParticipant
+    val sp: SimParticipant,
+    val type: Type
 ) {
     enum class Type {
         MANA,
@@ -12,8 +13,6 @@ class Resource(
         FOCUS,
         COMBO_POINT
     }
-
-    val type: Type = sp.character.klass.resourceType
 
     val initialAmount: Int
     var maxAmount: Int

--- a/src/commonMain/kotlin/character/classes/boss/Boss.kt
+++ b/src/commonMain/kotlin/character/classes/boss/Boss.kt
@@ -14,7 +14,7 @@ class Boss(override var baseStats: Stats) : Class(mapOf(), BossSpec()) {
     }
 
     override var buffs: List<Buff> = listOf()
-    override var resourceType: Resource.Type = Resource.Type.MANA
+    override val resourceType: MutableList<Resource.Type> = mutableListOf(Resource.Type.MANA)
     override var canDualWield: Boolean = false
     override var attackPowerFromAgility: Int = 0
     override var attackPowerFromStrength: Int = 0

--- a/src/commonMain/kotlin/character/classes/druid/Druid.kt
+++ b/src/commonMain/kotlin/character/classes/druid/Druid.kt
@@ -27,7 +27,7 @@ class Druid(talents: Map<String, Talent>, spec: Spec)  : Class(talents, spec) {
     )
     override var buffs: List<Buff> = listOf()
 
-    override var resourceType: Resource.Type = Resource.Type.MANA
+    override val resourceType: MutableList<Resource.Type> = mutableListOf(Resource.Type.MANA)
     override var canDualWield: Boolean = false
     override var attackPowerFromAgility: Int = 0
     override var attackPowerFromStrength: Int = 0

--- a/src/commonMain/kotlin/character/classes/hunter/Hunter.kt
+++ b/src/commonMain/kotlin/character/classes/hunter/Hunter.kt
@@ -84,7 +84,7 @@ class Hunter(talents: Map<String, Talent>, spec: Spec) : Class(talents, spec){
         }
     }
 
-    override val resourceType: Resource.Type = Resource.Type.MANA
+    override val resourceType: MutableList<Resource.Type> = mutableListOf(Resource.Type.MANA)
     override val canDualWield: Boolean = true
     override val attackPowerFromAgility: Int = 1
     override val attackPowerFromStrength: Int = 1

--- a/src/commonMain/kotlin/character/classes/hunter/pet/HunterPet.kt
+++ b/src/commonMain/kotlin/character/classes/hunter/pet/HunterPet.kt
@@ -69,7 +69,7 @@ abstract class HunterPet(petDamageMultiplier: Double) : Class(mapOf(), HunterPet
         PetUnleashedFury()
     )
 
-    override var resourceType: Resource.Type = Resource.Type.FOCUS
+    override val resourceType: MutableList<Resource.Type> = mutableListOf(Resource.Type.FOCUS)
     override var canDualWield: Boolean = false
     override var attackPowerFromAgility: Int = 0
     override var attackPowerFromStrength: Int = 2

--- a/src/commonMain/kotlin/character/classes/mage/Mage.kt
+++ b/src/commonMain/kotlin/character/classes/mage/Mage.kt
@@ -22,7 +22,7 @@ class Mage(talents: Map<String, Talent>, spec: Spec) : Class(talents, spec) {
         TODO("Not yet implemented")
     }
 
-    override val resourceType: Resource.Type
+    override val resourceType: MutableList<Resource.Type>
         get() = TODO("Not yet implemented")
     override val canDualWield: Boolean
         get() = TODO("Not yet implemented")

--- a/src/commonMain/kotlin/character/classes/paladin/Paladin.kt
+++ b/src/commonMain/kotlin/character/classes/paladin/Paladin.kt
@@ -22,7 +22,7 @@ class Paladin(talents: Map<String, Talent>, spec: Spec) : Class(talents, spec) {
         TODO("Not yet implemented")
     }
 
-    override val resourceType: Resource.Type
+    override val resourceType: MutableList<Resource.Type>
         get() = TODO("Not yet implemented")
     override val canDualWield: Boolean
         get() = TODO("Not yet implemented")

--- a/src/commonMain/kotlin/character/classes/priest/Priest.kt
+++ b/src/commonMain/kotlin/character/classes/priest/Priest.kt
@@ -22,7 +22,7 @@ class Priest(talents: Map<String, Talent>, spec: Spec) : Class(talents, spec) {
         TODO("Not yet implemented")
     }
 
-    override val resourceType: Resource.Type
+    override val resourceType: MutableList<Resource.Type>
         get() = TODO("Not yet implemented")
     override val canDualWield: Boolean
         get() = TODO("Not yet implemented")

--- a/src/commonMain/kotlin/character/classes/rogue/Rogue.kt
+++ b/src/commonMain/kotlin/character/classes/rogue/Rogue.kt
@@ -21,20 +21,13 @@ class Rogue(talents: Map<String, Talent>, spec: Spec) : Class(talents, spec) {
         TODO("Not yet implemented")
     }
 
-    override val resourceType: Resource.Type
-        get() = TODO("Not yet implemented")
-    override val canDualWield: Boolean
-        get() = TODO("Not yet implemented")
-    override val attackPowerFromAgility: Int
-        get() = TODO("Not yet implemented")
-    override val attackPowerFromStrength: Int
-        get() = TODO("Not yet implemented")
-    override val critPctPerAgility: Double
-        get() = TODO("Not yet implemented")
-    override val rangedAttackPowerFromAgility: Int
-        get() = TODO("Not yet implemented")
-    override val baseMana: Int
-        get() = TODO("Not yet implemented")
+    override val resourceType: MutableList<Resource.Type> = mutableListOf(Resource.Type.ENERGY, Resource.Type.COMBO_POINT)
+    override val canDualWield: Boolean = true
+    override val attackPowerFromAgility: Int = 1
+    override val attackPowerFromStrength: Int = 1
+    override val critPctPerAgility: Double = 1.0 / 40
+    override val rangedAttackPowerFromAgility: Int = 1
+    override val baseMana: Int = 0
     override val baseSpellCritChance: Double = 0.0
     override val dodgePctPerAgility: Double = 1.0 / 20.0
     override val baseDodgePct: Double = -0.59

--- a/src/commonMain/kotlin/character/classes/rogue/specs/Combat.kt
+++ b/src/commonMain/kotlin/character/classes/rogue/specs/Combat.kt
@@ -1,0 +1,26 @@
+package character.classes.rogue.specs
+
+import character.Spec
+import character.SpecEpDelta
+
+class Combat : Spec() {
+    override val name: String = "Combat"
+    override val epBaseStat: SpecEpDelta = attackPowerBase
+    override val epStatDeltas: List<SpecEpDelta> = dualWieldMeleeDeltas
+    override val benefitsFromMeleeWeaponDps = true
+
+    override fun redSocketEp(deltas: Map<String, Double>): Double {
+        // 10 str
+        return (deltas["strength"] ?: 0.0) * 10.0
+    }
+
+    override fun yellowSocketEp(deltas: Map<String, Double>): Double {
+        // 10 crit rating
+        return (deltas["meleeCritRating"] ?: 0.0) * 10.0
+    }
+
+    override fun blueSocketEp(deltas: Map<String, Double>): Double {
+        // 5 str
+        return (deltas["strength"] ?: 0.0) * 5.0
+    }
+}

--- a/src/commonMain/kotlin/character/classes/shaman/Shaman.kt
+++ b/src/commonMain/kotlin/character/classes/shaman/Shaman.kt
@@ -81,7 +81,7 @@ class Shaman(talents: Map<String, Talent>, spec: Spec) : Class(talents, spec) {
 
     override val buffs: List<Buff> = listOf()
 
-    override val resourceType: Resource.Type = Resource.Type.MANA
+    override val resourceType: MutableList<Resource.Type> = mutableListOf(Resource.Type.MANA)
 
     override val canDualWield: Boolean
         get() = talents["Dual Wield"]?.currentRank == 1

--- a/src/commonMain/kotlin/character/classes/warlock/Warlock.kt
+++ b/src/commonMain/kotlin/character/classes/warlock/Warlock.kt
@@ -79,7 +79,7 @@ class Warlock(talents: Map<String, Talent>, spec: Spec) : Class(talents, spec) {
         }
     }
 
-    override val resourceType: Resource.Type = Resource.Type.MANA
+    override val resourceType: MutableList<Resource.Type> = mutableListOf(Resource.Type.MANA)
     override val canDualWield: Boolean = false
     override val attackPowerFromAgility: Int = 0
     override val attackPowerFromStrength: Int = 0

--- a/src/commonMain/kotlin/character/classes/warlock/abilities/DemonicSacrifice.kt
+++ b/src/commonMain/kotlin/character/classes/warlock/abilities/DemonicSacrifice.kt
@@ -3,6 +3,7 @@ package character.classes.warlock.abilities
 import character.Ability
 import character.Buff
 import character.Stats
+import character.Resource
 import sim.SimIteration
 import sim.SimParticipant
 
@@ -16,7 +17,7 @@ class DemonicSacrificeSuccubus : DemonicSacrifice("Succubus", { Stats(shadowDama
         const val name = "Demonic Sacrifice (Succubus)"
     }
 }
-class DemonicSacrificeFelguard : DemonicSacrifice("Felguard", { sp -> Stats(shadowDamageMultiplier = 1.15, manaPer5Seconds = (sp.resource.maxAmount * 0.02 * 0.8).toInt())}) {
+class DemonicSacrificeFelguard : DemonicSacrifice("Felguard", { sp -> Stats(shadowDamageMultiplier = 1.15, manaPer5Seconds = (sp.getResource((Resource.Type.MANA)).maxAmount * 0.02 * 0.8).toInt())}) {
     companion object {
         const val name = "Demonic Sacrifice (Felguard)"
     }

--- a/src/commonMain/kotlin/character/classes/warrior/Warrior.kt
+++ b/src/commonMain/kotlin/character/classes/warrior/Warrior.kt
@@ -82,7 +82,7 @@ class Warrior(talents: Map<String, Talent>, spec: Spec) : Class(talents, spec) {
         }
     }
 
-    override val resourceType: Resource.Type = Resource.Type.RAGE
+    override val resourceType: MutableList<Resource.Type> = mutableListOf(Resource.Type.RAGE)
     override val canDualWield: Boolean = true
     override val attackPowerFromAgility: Int = 0
     override val attackPowerFromStrength: Int = 2

--- a/src/commonMain/kotlin/character/classes/warrior/abilities/Execute.kt
+++ b/src/commonMain/kotlin/character/classes/warrior/abilities/Execute.kt
@@ -40,11 +40,11 @@ class Execute : Ability() {
 
     override fun cast(sp: SimParticipant) {
         val item = sp.character.gear.mainHand
-        val damage = 925.0 + sp.resource.currentAmount * 21
+        val damage = 925.0 + (sp.getResource(resourceType(sp))).currentAmount * 21
         val result = Melee.attackRoll(sp, damage, item, isWhiteDmg = false)
 
         // Drain rage
-        sp.subtractResource(sp.resource.currentAmount, Resource.Type.RAGE, "Execute (extra)")
+        sp.subtractResource(sp.getResource(Resource.Type.RAGE).currentAmount, Resource.Type.RAGE, "Execute (extra)")
 
         // Save last hit state and fire event
         val event = Event(

--- a/src/commonMain/kotlin/character/races/abilities/Berserking.kt
+++ b/src/commonMain/kotlin/character/races/abilities/Berserking.kt
@@ -16,11 +16,15 @@ class Berserking : Ability() {
     override fun gcdMs(sp: SimParticipant): Int = sp.physicalGcd().toInt()
 
     override fun resourceType(sp: SimParticipant): Resource.Type {
-        return sp.character.klass.resourceType
+        if(sp.resource.containsKey(Resource.Type.MANA)) return Resource.Type.MANA 
+        if(sp.resource.containsKey(Resource.Type.ENERGY)) return Resource.Type.ENERGY
+        if(sp.resource.containsKey(Resource.Type.RAGE)) return Resource.Type.RAGE
+
+        return Resource.Type.MANA
     }
 
     override fun resourceCost(sp: SimParticipant): Double {
-        return when(sp.character.klass.resourceType) {
+        return when(resourceType(sp)) {
             Resource.Type.MANA -> 0.06 * sp.character.klass.baseMana
             Resource.Type.ENERGY -> 10.0
             Resource.Type.RAGE -> 5.0

--- a/src/commonMain/kotlin/data/abilities/raid/JudgementOfWisdom.kt
+++ b/src/commonMain/kotlin/data/abilities/raid/JudgementOfWisdom.kt
@@ -44,7 +44,7 @@ class JudgementOfWisdom : Ability() {
             override fun percentChance(sp: SimParticipant): Double = 50.0
 
             override fun proc(sp: SimParticipant, items: List<Item>?, ability: Ability?, event: Event?) {
-                if(sp.character.klass.resourceType == Resource.Type.MANA) {
+                if(sp.resource.containsKey(Resource.Type.MANA)) {
                     sp.addResource(74, Resource.Type.MANA, name)
                 }
             }

--- a/src/commonMain/kotlin/sim/Event.kt
+++ b/src/commonMain/kotlin/sim/Event.kt
@@ -2,12 +2,14 @@ package sim
 
 import character.Buff
 import data.Constants
+import character.Resource
 
 data class Event(
     var tick: Int = -1,
     var timeMs: Int = -1,
     val abilityName: String? = null,
     val buff: Buff? = null,
+    val resourceType: Resource.Type? = null,
     val buffStacks: Int = 0,
     val eventType: Type,
     var target: SimParticipant? = null,

--- a/src/commonMain/kotlin/sim/SimIteration.kt
+++ b/src/commonMain/kotlin/sim/SimIteration.kt
@@ -76,7 +76,7 @@ class SimIteration(
         // MP5
         if (elapsedTimeMs - lastMp5Tick >= 5000) {
             allParticipants.forEach {
-                if (it.character.klass.resourceType == Resource.Type.MANA) {
+                if (it.resource.containsKey(Resource.Type.MANA)) {
                     it.addResource(it.stats.manaPer5Seconds, Resource.Type.MANA, "MP5")
                 }
             }

--- a/src/commonMain/kotlin/sim/SimParticipant.kt
+++ b/src/commonMain/kotlin/sim/SimParticipant.kt
@@ -465,18 +465,16 @@ class SimParticipant(val character: Character, val rotation: Rotation, val sim: 
             return
         }
 
-        if(res.type == type) {
-            res.add(amount)
+        res.add(amount)
 
-            logEvent(Event(
-                eventType = Event.Type.RESOURCE_CHANGED,
-                amount = res.currentAmount.toDouble(),
-                delta = amount.toDouble(),
-                amountPct = res.currentAmount / res.maxAmount.toDouble() * 100.0,
-                resourceType = res.type,
-                abilityName = abilityName
-            ))
-        }
+        logEvent(Event(
+            eventType = Event.Type.RESOURCE_CHANGED,
+            amount = res.currentAmount.toDouble(),
+            delta = amount.toDouble(),
+            amountPct = res.currentAmount / res.maxAmount.toDouble() * 100.0,
+            resourceType = res.type,
+            abilityName = abilityName
+        ))
     }
 
     fun subtractResource(amount: Int, type: Resource.Type, abilityName: String) {
@@ -487,18 +485,16 @@ class SimParticipant(val character: Character, val rotation: Rotation, val sim: 
             return
         }
 
-        if(res.type == type) {
-            res.subtract(amount)
+        res.subtract(amount)
 
-            logEvent(Event(
-                eventType = Event.Type.RESOURCE_CHANGED,
-                amount = res.currentAmount.toDouble(),
-                delta = amount.toDouble(),
-                amountPct = res.currentAmount / res.maxAmount.toDouble() * 100.0,
-                resourceType = res.type,
-                abilityName = abilityName
-            ))
-        }
+        logEvent(Event(
+            eventType = Event.Type.RESOURCE_CHANGED,
+            amount = res.currentAmount.toDouble(),
+            delta = amount.toDouble(),
+            amountPct = res.currentAmount / res.maxAmount.toDouble() * 100.0,
+            resourceType = res.type,
+            abilityName = abilityName
+        ))
     }
 
     fun hasEnoughResource(type: Resource.Type, amount: Double) : Boolean {

--- a/src/commonMain/kotlin/sim/SimParticipant.kt
+++ b/src/commonMain/kotlin/sim/SimParticipant.kt
@@ -22,7 +22,7 @@ class SimParticipant(val character: Character, val rotation: Rotation, val sim: 
     val logger = KotlinLogging.logger {}
 
     var stats: Stats = Stats()
-    lateinit var resource: Resource
+    lateinit var resource: MutableMap<Resource.Type, Resource>
 
     var mhAutoAttack: AutoAttackBase? = null
     var ohAutoAttack: AutoAttackBase? = null
@@ -90,8 +90,12 @@ class SimParticipant(val character: Character, val rotation: Rotation, val sim: 
         // Compute initial stats
         recomputeStats()
 
-        // Initialize our subject resource
-        resource = Resource(this)
+        // Initialize our subject resource(s)
+        resource = mutableMapOf()
+        character.klass.resourceType.forEach { 
+            var res = Resource(this, it)
+            resource.put(res.type, res) 
+        }
 
         return this
     }
@@ -141,7 +145,7 @@ class SimParticipant(val character: Character, val rotation: Rotation, val sim: 
             // If we are not casting, and have an ability queued up, actually cast it
             if(castingRule != null) {
                 // Double check resource, since it could have changed since the start of the attack
-                if(castingRule!!.ability.resourceCost(this) <= resource.currentAmount) {
+                if(hasEnoughResource(castingRule!!.ability.resourceType(this), castingRule!!.ability.resourceCost(this))){
                     castingRule!!.ability.beforeCast(this)
                     castingRule!!.ability.cast(this)
                     castingRule!!.ability.afterCast(this)
@@ -454,35 +458,60 @@ class SimParticipant(val character: Character, val rotation: Rotation, val sim: 
     fun addResource(amount: Int, type: Resource.Type, abilityName: String) {
         if(amount == 0) return
 
-        if(resource.type == type) {
-            resource.add(amount)
+        var res = resource[type]
+
+        if(res == null) {
+            logger.debug { "Attempted to add resource type $type that is not present for participant" }
+            return
+        }
+
+        if(res.type == type) {
+            res.add(amount)
 
             logEvent(Event(
                 eventType = Event.Type.RESOURCE_CHANGED,
-                amount = resource.currentAmount.toDouble(),
+                amount = res.currentAmount.toDouble(),
                 delta = amount.toDouble(),
-                amountPct = resource.currentAmount / resource.maxAmount.toDouble() * 100.0,
+                amountPct = res.currentAmount / res.maxAmount.toDouble() * 100.0,
+                resourceType = res.type,
                 abilityName = abilityName
             ))
-        } else {
-            logger.debug { "Attempted to add resource type $type but subject resource is ${resource.type}" }
         }
     }
 
     fun subtractResource(amount: Int, type: Resource.Type, abilityName: String) {
-        if(resource.type == type) {
-            resource.subtract(amount)
+        var res = resource[type]
+
+        if(res == null) {
+            logger.debug { "Attempted to subtract resource type $type that is not present for participant" }
+            return
+        }
+
+        if(res.type == type) {
+            res.subtract(amount)
 
             logEvent(Event(
                 eventType = Event.Type.RESOURCE_CHANGED,
-                amount = resource.currentAmount.toDouble(),
-                delta = -1 * amount.toDouble(),
-                amountPct = resource.currentAmount / resource.maxAmount.toDouble() * 100.0,
+                amount = res.currentAmount.toDouble(),
+                delta = amount.toDouble(),
+                amountPct = res.currentAmount / res.maxAmount.toDouble() * 100.0,
+                resourceType = res.type,
                 abilityName = abilityName
             ))
-        } else {
-            logger.debug { "Attempted to subtract resource type $type but subject resource is ${resource.type}" }
         }
+    }
+
+    fun hasEnoughResource(type: Resource.Type, amount: Double) : Boolean {
+        if(amount == 0.0){return false} // for trinkets and other items that have MANA as the default
+
+        if(amount <= getResource(type).currentAmount) { 
+            return true 
+        }
+        return false
+    }
+
+    fun getResource(type: Resource.Type) : Resource {
+        return resource[type] ?: throw Exception("Tried to access a resource that is not present for participant")
     }
 
     fun fireProc(triggers: List<Proc.Trigger>, items: List<Item>?, ability: Ability?, event: Event?) {
@@ -539,7 +568,6 @@ class SimParticipant(val character: Character, val rotation: Rotation, val sim: 
         }
 
         logger.trace { "Got event: ${event.abilityName} - ${event.tick} (${event.tick * sim.opts.stepMs}ms) - ${event.eventType} - ${event.result} - ${event.amount}" }
-
         events.add(event)
     }
 

--- a/src/commonMain/kotlin/sim/config/ConfigYml.kt
+++ b/src/commonMain/kotlin/sim/config/ConfigYml.kt
@@ -91,6 +91,7 @@ data class RotationRuleCriterion(
     val bool: Boolean? = null,
     val swingType: String? = null,
     val maxClipSeconds: Double? = null,
+    val resourceType: String? = null
 )
 
 @JsExport

--- a/src/commonMain/kotlin/sim/rotation/Rotation.kt
+++ b/src/commonMain/kotlin/sim/rotation/Rotation.kt
@@ -44,7 +44,7 @@ class Rotation(
             (!onGcd || (onGcd && it.ability.castableOnGcd)) &&
             it.ability.available(sp) &&
             it.satisfied(sp) &&
-            it.ability.resourceCost(sp) <= sp.resource.currentAmount
+            sp.hasEnoughResource(it.ability.resourceType(sp), it.ability.resourceCost(sp))
         }
     }
 }

--- a/src/commonMain/kotlin/sim/rotation/criteria/ResourceMissingGte.kt
+++ b/src/commonMain/kotlin/sim/rotation/criteria/ResourceMissingGte.kt
@@ -3,6 +3,7 @@ package sim.rotation.criteria
 import sim.SimParticipant
 import sim.config.RotationRuleCriterion
 import sim.rotation.Criterion
+import character.Resource
 
 class ResourceMissingGte(data: RotationRuleCriterion) : Criterion(Type.RESOURCE_MISSING_GTE, data) {
     val amount: Int? = try {
@@ -15,7 +16,25 @@ class ResourceMissingGte(data: RotationRuleCriterion) : Criterion(Type.RESOURCE_
         null
     }
 
+    inline fun <reified T : Enum<T>> valueOf(type: String): T? {
+        return java.lang.Enum.valueOf(T::class.java, type)
+    }
+
+    val resourceType: Resource.Type? = try {
+        valueOf<Resource.Type>((data.resourceType as String))
+    } catch (e: NullPointerException) {
+        logger.warn { "Field 'resourceType' is required for criterion $type" }
+        null
+    } catch (e: IllegalArgumentException) {
+        logger.warn { "Field 'resourceType' is not a valid Resource Type for criterion $type" }
+        null
+    } catch(e: Exception) {
+        logger.warn { "Field 'resourceType' must be a string for criterion $type" }
+        null
+    }
+
     override fun satisfied(sp: SimParticipant): Boolean {
-        return amount != null && sp.resource.currentAmount <= sp.resource.maxAmount - amount
+        if(amount == null || resourceType == null) {return false}
+        return sp.getResource(resourceType).currentAmount <= sp.getResource(resourceType).maxAmount - amount
     }
 }

--- a/src/commonMain/kotlin/sim/rotation/criteria/ResourcePctGte.kt
+++ b/src/commonMain/kotlin/sim/rotation/criteria/ResourcePctGte.kt
@@ -3,6 +3,7 @@ package sim.rotation.criteria
 import sim.SimParticipant
 import sim.config.RotationRuleCriterion
 import sim.rotation.Criterion
+import character.Resource
 
 class ResourcePctGte(data: RotationRuleCriterion) : Criterion(Type.RESOURCE_PCT_GTE, data) {
     val pct: Int? = try {
@@ -15,7 +16,25 @@ class ResourcePctGte(data: RotationRuleCriterion) : Criterion(Type.RESOURCE_PCT_
         null
     }
 
+    inline fun <reified T : Enum<T>> valueOf(type: String): T? {
+        return java.lang.Enum.valueOf(T::class.java, type)
+    }
+
+    val resourceType: Resource.Type? = try {
+        valueOf<Resource.Type>((data.resourceType as String))
+    } catch (e: NullPointerException) {
+        logger.warn { "Field 'resourceType' is required for criterion $type" }
+        null
+    } catch (e: IllegalArgumentException) {
+        logger.warn { "Field 'resourceType' is not a valid Resource Type for criterion $type" }
+        null
+    } catch(e: Exception) {
+        logger.warn { "Field 'resourceType' must be a string for criterion $type" }
+        null
+    }
+
     override fun satisfied(sp: SimParticipant): Boolean {
-        return pct != null && sp.resource.currentAmount >= sp.resource.maxAmount * (pct / 100.0)
+        if(pct == null || resourceType == null) {return false}
+        return sp.getResource(resourceType).currentAmount >= sp.getResource(resourceType).maxAmount * (pct / 100.0)
     }
 }

--- a/src/commonMain/kotlin/sim/rotation/criteria/ResourcePctLte.kt
+++ b/src/commonMain/kotlin/sim/rotation/criteria/ResourcePctLte.kt
@@ -3,6 +3,7 @@ package sim.rotation.criteria
 import sim.SimParticipant
 import sim.config.RotationRuleCriterion
 import sim.rotation.Criterion
+import character.Resource
 
 class ResourcePctLte(data: RotationRuleCriterion) : Criterion(Type.RESOURCE_PCT_LTE, data) {
     val pct: Int? = try {
@@ -15,7 +16,25 @@ class ResourcePctLte(data: RotationRuleCriterion) : Criterion(Type.RESOURCE_PCT_
         null
     }
 
+    inline fun <reified T : Enum<T>> valueOf(type: String): T? {
+        return java.lang.Enum.valueOf(T::class.java, type)
+    }
+
+    val resourceType: Resource.Type? = try {
+        valueOf<Resource.Type>((data.resourceType as String))
+    } catch (e: NullPointerException) {
+        logger.warn { "Field 'resourceType' is required for criterion $type" }
+        null
+    } catch (e: IllegalArgumentException) {
+        logger.warn { "Field 'resourceType' is not a valid Resource Type for criterion $type" }
+        null
+    } catch(e: Exception) {
+        logger.warn { "Field 'resourceType' must be a string for criterion $type" }
+        null
+    }
+
     override fun satisfied(sp: SimParticipant): Boolean {
-        return pct != null && sp.resource.currentAmount <= sp.resource.maxAmount * (pct / 100.0)
+        if(pct == null || resourceType == null) {return false}
+        return sp.getResource(resourceType).currentAmount <= sp.getResource(resourceType).maxAmount * (pct / 100.0)
     }
 }

--- a/ui/src/presets/samples/shaman_ele_preraid.yml
+++ b/ui/src/presets/samples/shaman_ele_preraid.yml
@@ -151,6 +151,7 @@ rotation:
       criteria:
         - type: RESOURCE_MISSING_GTE
           amount: 1500
+          resourceType: MANA
         - type: ABILITY_COOLDOWN_GTE
           ability: Super Mana Potion
           seconds: 1
@@ -158,6 +159,7 @@ rotation:
       criteria:
         - type: RESOURCE_MISSING_GTE
           amount: 1500
+          resourceType: MANA
         - type: FIGHT_TIME_REMAINING_GTE
           seconds: 90
     # Mana pot if we've used enough mana an there's a lot of fight left
@@ -167,6 +169,7 @@ rotation:
           seconds: 135
         - type: RESOURCE_MISSING_GTE
           amount: 3000
+          resourceType: MANA
     - name: Destruction Potion
       criteria:
         # Allow some slush time for debuffs to get rolling before using potions
@@ -177,6 +180,7 @@ rotation:
           seconds: 60
         - type: RESOURCE_PCT_GTE
           pct: 60
+          resourceType: MANA
     - name: Elemental Mastery
     # Always cast CL with EM up
     - name: Chain Lightning
@@ -200,6 +204,7 @@ rotation:
           seconds: 60
         - type: RESOURCE_PCT_GTE
           pct: 60
+          resourceType: MANA
     - name: Lightning Bolt
 
 # Raid and group setup

--- a/ui/src/presets/samples/shaman_enh_subele_preraid.yml
+++ b/ui/src/presets/samples/shaman_enh_subele_preraid.yml
@@ -140,6 +140,7 @@ rotation:
         # If our mana is 30% or lower, cast Shamanistic Rage
         - type: RESOURCE_PCT_LTE
           pct: 30
+          resourceType: MANA
     - name: Stormstrike
     - name: Windfury Totem (Rank 1)
       criteria:

--- a/ui/src/presets/samples/shaman_enh_subresto_preraid.yml
+++ b/ui/src/presets/samples/shaman_enh_subresto_preraid.yml
@@ -136,6 +136,7 @@ rotation:
         # If our mana is 30% or lower, cast Shamanistic Rage
         - type: RESOURCE_PCT_LTE
           pct: 30
+          resourceType: MANA
     - name: Stormstrike
     - name: Windfury Totem (Rank 1)
       criteria:

--- a/ui/src/presets/samples/shaman_enh_subresto_preraid_annihilator_dw.yml
+++ b/ui/src/presets/samples/shaman_enh_subresto_preraid_annihilator_dw.yml
@@ -136,6 +136,7 @@ rotation:
         # If our mana is 30% or lower, cast Shamanistic Rage
         - type: RESOURCE_PCT_LTE
           pct: 30
+          resourceType: MANA
     - name: Stormstrike
     - name: Windfury Totem (Rank 1)
       criteria:

--- a/ui/src/presets/samples/shaman_enh_subresto_preraid_annihilator_oh.yml
+++ b/ui/src/presets/samples/shaman_enh_subresto_preraid_annihilator_oh.yml
@@ -136,6 +136,7 @@ rotation:
         # If our mana is 30% or lower, cast Shamanistic Rage
         - type: RESOURCE_PCT_LTE
           pct: 30
+          resourceType: MANA
     - name: Stormstrike
     - name: Windfury Totem (Rank 1)
       criteria:

--- a/ui/src/presets/samples/warlock_affliction_ds_preraid.yml
+++ b/ui/src/presets/samples/warlock_affliction_ds_preraid.yml
@@ -120,10 +120,12 @@ rotation:
       criteria:
         - type: RESOURCE_MISSING_GTE
           amount: 1500
+          resourceType: MANA
     - name: Life Tap
       criteria:
         - type: RESOURCE_PCT_LTE
           pct: 10
+          resourceType: MANA
     - name: Curse of Doom
       criteria:
         - type: DEBUFF_DURATION_LTE

--- a/ui/src/presets/samples/warlock_affliction_ruin_preraid.yml
+++ b/ui/src/presets/samples/warlock_affliction_ruin_preraid.yml
@@ -121,10 +121,12 @@ rotation:
       criteria:
         - type: RESOURCE_MISSING_GTE
           amount: 1500
+          resourceType: MANA
     - name: Life Tap
       criteria:
         - type: RESOURCE_PCT_LTE
           pct: 10
+          resourceType: MANA
     - name: Curse of Doom
       criteria:
         - type: DEBUFF_DURATION_LTE

--- a/ui/src/presets/samples/warlock_affliction_ua_preraid.yml
+++ b/ui/src/presets/samples/warlock_affliction_ua_preraid.yml
@@ -121,10 +121,12 @@ rotation:
       criteria:
         - type: RESOURCE_MISSING_GTE
           amount: 1500
+          resourceType: MANA
     - name: Life Tap
       criteria:
         - type: RESOURCE_PCT_LTE
           pct: 10
+          resourceType: MANA
     - name: Curse of Doom
       criteria:
         - type: DEBUFF_DURATION_LTE

--- a/ui/src/presets/samples/warlock_destruction_fire_preraid.yml
+++ b/ui/src/presets/samples/warlock_destruction_fire_preraid.yml
@@ -116,10 +116,12 @@ rotation:
       criteria:
         - type: RESOURCE_MISSING_GTE
           amount: 1500
+          resourceType: MANA
     - name: Life Tap
       criteria:
         - type: RESOURCE_PCT_LTE
           pct: 10
+          resourceType: MANA
     - name: Curse of Doom
       criteria:
         - type: DEBUFF_DURATION_LTE

--- a/ui/src/presets/samples/warlock_destruction_shadow_preraid.yml
+++ b/ui/src/presets/samples/warlock_destruction_shadow_preraid.yml
@@ -118,10 +118,12 @@ rotation:
       criteria:
         - type: RESOURCE_MISSING_GTE
           amount: 1500
+          resourceType: MANA
     - name: Life Tap
       criteria:
         - type: RESOURCE_PCT_LTE
           pct: 10
+          resourceType: MANA
     - name: Curse of Doom
       criteria:
         - type: DEBUFF_DURATION_LTE

--- a/ui/src/presets/samples/warrior_arms_preraid.yml
+++ b/ui/src/presets/samples/warrior_arms_preraid.yml
@@ -159,6 +159,7 @@ rotation:
         # Cast HS if we have excess rage
         - type: RESOURCE_PCT_GTE
           pct: 90
+          resourceType: RAGE
 
 # Raid and group setup
 # These are buffs/debuffs you are not personally responsible for applying

--- a/ui/src/presets/samples/warrior_fury_preraid.yml
+++ b/ui/src/presets/samples/warrior_fury_preraid.yml
@@ -144,6 +144,7 @@ rotation:
         # Cast HS if we have 60 rage or more
         - type: RESOURCE_PCT_GTE
           pct: 60
+          resourceType: RAGE
     - name: Battle Shout
       criteria:
         - type: BUFF_DURATION_LTE


### PR DESCRIPTION
I wanted to implement Rogues and saw that it's currently not possible to use multiple resources for one participant (Energy + CP for Rogues, or even Energy + CP + Mana for Druids).

So I added multiple resources, changed the relevant Criteria to include a resourceType (for RESOURCE_MISSING_GTE etc.) and a few other smaller things.

I never used Kotlin before and was unsure about a few things, let me know if this PR is acceptable or not.

