### PR TITLE
Fix Soulfrost enchant spell damage

### DIFF
--- a/src/commonMain/kotlin/data/enchants/Soulfrost.kt
+++ b/src/commonMain/kotlin/data/enchants/Soulfrost.kt
@@ -15,8 +15,8 @@ class Soulfrost(item: Item) : Enchant(item) {
 
     override fun modifyStats(sp: SimParticipant): Stats {
         return Stats(
-            frostDamage = 50,
-            shadowDamage = 50
+            frostDamage = 54,
+            shadowDamage = 54
         )
     }
 }


### PR DESCRIPTION
https://tbc.wowhead.com/spell=46538/enchant-weapon-soulfrost