### PR TITLE
Add Divine and Improved Divine Spirit to raid buffs

### DIFF
--- a/src/commonMain/kotlin/data/abilities/raid/DivineSpirit.kt
+++ b/src/commonMain/kotlin/data/abilities/raid/DivineSpirit.kt
@@ -1,0 +1,30 @@
+package data.abilities.raid
+
+import character.Ability
+import character.Buff
+import character.Stats
+import mechanics.Rating
+import sim.SimParticipant
+
+class DivineSpirit : Ability() {
+    companion object {
+        const val name = "Divine Spirit"
+    }
+
+    override val id: Int = 25312
+    override val name: String = Companion.name
+    override fun gcdMs(sp: SimParticipant): Int = 0
+
+    val buff = object : Buff() {
+        override val name: String = Companion.name
+        override val durationMs: Int = -1
+
+        override fun modifyStats(sp: SimParticipant): Stats {
+            return Stats(spirit = 50)
+        }
+    }
+
+    override fun cast(sp: SimParticipant) {
+        sp.sim.addRaidBuff(buff)
+    }
+}

--- a/src/commonMain/kotlin/data/abilities/raid/ImprovedDivineSpirit.kt
+++ b/src/commonMain/kotlin/data/abilities/raid/ImprovedDivineSpirit.kt
@@ -1,0 +1,39 @@
+package data.abilities.raid
+
+import character.Ability
+import character.Buff
+import character.Stats
+import mechanics.Rating
+import sim.SimParticipant
+
+class ImprovedDivineSpirit : Ability() {
+    companion object {
+        const val name = "Improved Divine Spirit"
+    }
+
+    override val id: Int = 33182
+    override val name: String = Companion.name
+    override fun gcdMs(sp: SimParticipant): Int = 0
+
+    val buff = object : Buff() {
+        override val name: String = Companion.name
+        override val durationMs: Int = -1
+
+        override fun modifyStats(sp: SimParticipant): Stats {
+            // assumes max rank
+            val increase = (0.1 * sp.stats.spirit).toInt();
+
+            return Stats(
+                spellDamage = increase,
+                spellHealing = increase,
+            )
+        }
+    }
+
+    override fun cast(sp: SimParticipant) {
+        // Ensure Divine Spirit buff is present as it's not
+        // possible to have Improved Divine Spirit without it
+        sp.sim.addRaidBuff(DivineSpirit().buff)
+        sp.sim.addRaidBuff(buff)
+    }
+}

--- a/src/commonMain/kotlin/data/abilities/raid/RaidAbilities.kt
+++ b/src/commonMain/kotlin/data/abilities/raid/RaidAbilities.kt
@@ -10,6 +10,7 @@ object RaidAbilities {
     val raidBuffs: Array<Ability> = arrayOf(
         BlessingOfKings(),
         Bloodlust(),
+        DivineSpirit(),
         DrumsOfBattle(),
         FerociousInspiration(1),
         FerociousInspiration(2),
@@ -19,6 +20,7 @@ object RaidAbilities {
         ImprovedBattleShout(),
         ImprovedBlessingOfMight(),
         ImprovedBlessingOfWisdom(),
+        ImprovedDivineSpirit(),
         ImprovedMarkOfTheWild(),
         ImprovedSanctityAura(),
         ImprovedSealOfTheCrusader(),


### PR DESCRIPTION
Pretty simple addition. In the event the user doesn't check the Divine Spirit buff they will still receive it from Improved Divine Spirit. The separate Divine Spirit buff still allows for adding the 50 spirit to test without Improved if desired.