### PR TITLE
Add BUFF_STACKS_GTE criteria check

### DIFF
--- a/src/commonMain/kotlin/sim/rotation/Criterion.kt
+++ b/src/commonMain/kotlin/sim/rotation/Criterion.kt
@@ -25,7 +25,8 @@ abstract class Criterion(val type: Type, val data: RotationRuleCriterion) {
         FIGHT_TIME_REMAINING_LTE,
         IS_EXECUTE_PHASE,
         PET_ACTIVE,
-        BUFF_STACKS_LTE
+        BUFF_STACKS_LTE,
+        BUFF_STACKS_GTE,
     }
 
     companion object {
@@ -54,6 +55,7 @@ abstract class Criterion(val type: Type, val data: RotationRuleCriterion) {
                 Type.IS_EXECUTE_PHASE -> IsExecutePhase(data)
                 Type.PET_ACTIVE -> PetActive(data)
                 Type.BUFF_STACKS_LTE -> BuffStacksLte(data)
+                Type.BUFF_STACKS_GTE -> BuffStacksGte(data)
                 else -> {
                     logger.warn { "Unknown rotation criterion: $typeName" }
                     null

--- a/src/commonMain/kotlin/sim/rotation/criteria/BuffStacksGte.kt
+++ b/src/commonMain/kotlin/sim/rotation/criteria/BuffStacksGte.kt
@@ -1,0 +1,31 @@
+package sim.rotation.criteria
+
+import sim.SimParticipant
+import sim.config.RotationRuleCriterion
+import sim.rotation.Criterion
+
+class BuffStacksGte(data: RotationRuleCriterion) : Criterion(Type.BUFF_STACKS_LTE, data) {
+    val buff: String? = try {
+        data.buff as String
+    } catch (e: Exception) {
+        logger.warn { "Field 'buff' is required for criterion $type" }
+        null
+    }
+
+    val stacks: Int? = try {
+        (data.stacks as Int).coerceAtLeast(0)
+    } catch (e: NullPointerException) {
+        logger.warn { "Field 'stacks' is required for criterion $type" }
+        null
+    } catch(e: Exception) {
+        logger.warn { "Field 'stacks' must be an integer for criterion $type" }
+        null
+    }
+
+    override fun satisfied(sp: SimParticipant): Boolean {
+        if(buff == null || stacks == null) return false
+
+        val state = sp.buffs[buff]?.state(sp)
+        return state != null && state.currentStacks >= stacks
+    }
+}


### PR DESCRIPTION
Added the opposite of BUFF_STACKS_LTE. At the moment this has a use case with Shadow Weaving stacks for trinket / ability usage.