### PR TITLE
Add Malediction as raid debuff

### DIFF
--- a/src/commonMain/kotlin/data/abilities/raid/CurseOfTheElements.kt
+++ b/src/commonMain/kotlin/data/abilities/raid/CurseOfTheElements.kt
@@ -1,7 +1,7 @@
 package data.abilities.raid
 
 import character.*
-import character.classes.warlock.talents.Malediction
+import character.classes.warlock.talents.Malediction as MaledictionTalent
 import sim.SimParticipant
 
 class CurseOfTheElements : Ability() {
@@ -20,8 +20,9 @@ class CurseOfTheElements : Ability() {
         override val hidden: Boolean = true
 
         override fun modifyStats(sp: SimParticipant): Stats {
-            val malediction = sp.character.klass.talents[Malediction.name] as Malediction?
-            val additionalDmgPct = (malediction?.currentRank ?: 0) * 0.01
+            val maledictionTalent = sp.character.klass.talents[MaledictionTalent.name] as MaledictionTalent?
+            val talentDmgPct = (maledictionTalent?.currentRank ?: 0) * 0.01
+            val additionalDmgPct = if(sp.buffs[Malediction.name] != null) 0.03 else talentDmgPct
 
             return Stats(
                 arcaneDamageMultiplier = 1.1 + additionalDmgPct,

--- a/src/commonMain/kotlin/data/abilities/raid/Malediction.kt
+++ b/src/commonMain/kotlin/data/abilities/raid/Malediction.kt
@@ -1,0 +1,24 @@
+package data.abilities.raid
+
+import character.*
+import sim.SimParticipant
+
+class Malediction : Ability() {
+    companion object {
+        const val name = "Malediction"
+    }
+
+    override val id: Int = 32484
+    override val name: String = Companion.name
+    override fun gcdMs(sp: SimParticipant): Int = 0
+
+    val buff = object : Buff() {
+        override val name: String = Companion.name
+        override val durationMs: Int = -1
+        override val hidden: Boolean = true
+    }
+
+    override fun cast(sp: SimParticipant) {
+        sp.sim.addRaidBuff(buff)
+    }
+}

--- a/src/commonMain/kotlin/data/abilities/raid/RaidAbilities.kt
+++ b/src/commonMain/kotlin/data/abilities/raid/RaidAbilities.kt
@@ -48,6 +48,7 @@ object RaidAbilities {
         ImprovedFaerieFire(),
         ImprovedScorch(),
         JudgementOfWisdom(),
+        Malediction(),
         Misery(),
         ShadowWeaving(),
         Stormstrike(),


### PR DESCRIPTION
Adds Malediction as a raid "debuff" (3% more spell damage to the four schools). The hidden buff only enhances Curse of Elements if present and is prioritized when checked over a Warlocks talent for it.