### PR TITLE
Fix Dark Iron Smoking Pipe trinket not applying buff

### DIFF
--- a/src/commonMain/kotlin/data/buffs/Buffs.kt
+++ b/src/commonMain/kotlin/data/buffs/Buffs.kt
@@ -133,6 +133,7 @@ object Buffs {
             43716 -> BerserkersCall()
             45354 -> ShardOfContempt()
             45355 -> BlackenedNaaruSliver()
+            51953 -> DarkIronSmokingPipe()
 
             //Weapons
             16916 -> KhoriumChampion(item)

--- a/src/commonMain/kotlin/data/buffs/DarkIronSmokingPipe.kt
+++ b/src/commonMain/kotlin/data/buffs/DarkIronSmokingPipe.kt
@@ -1,0 +1,41 @@
+package data.buffs
+
+import character.Ability
+import character.Buff
+import character.Stats
+import sim.SimParticipant
+
+class DarkIronSmokingPipe : Buff() {
+    companion object {
+        const val name = "Dark Iron Smoking Pipe (static)"
+    }
+    override val id: Int = 51953
+    override val name: String = Companion.name
+    override val durationMs: Int = -1
+    override val hidden: Boolean = true
+
+    val buffDurationMs = 20000
+    val buff = object : Buff() {
+        override val name: String  = "Dark Iron Pipeweed"
+        override val durationMs: Int = buffDurationMs
+
+        override fun modifyStats(sp: SimParticipant): Stats? {
+            return Stats(spellDamage = 155)
+        }
+    }
+
+    val ability = object : Ability() {
+        override val id: Int = 51953
+        override val name: String = Companion.name
+        override fun gcdMs(sp: SimParticipant): Int = 0
+        override fun cooldownMs(sp: SimParticipant): Int = 120000
+
+        override fun trinketLockoutMs(sp: SimParticipant): Int = buffDurationMs
+
+        override fun cast(sp: SimParticipant) {
+            sp.addBuff(buff)
+        }
+    }
+
+    override fun activeTrinketAbility(sp: SimParticipant): Ability = ability
+}


### PR DESCRIPTION
I saw the buff was in the itemprocs auto generated file, but not sure if the buffs themselves are required to be manually done. I saw the Icon of Silver Crescent and basically just verbatim copied since it's the same trinket with a different id / name.